### PR TITLE
Fixed errors with DB regarding backticks, group field names and primary keys

### DIFF
--- a/Pods_Jobs_Queue_API.php
+++ b/Pods_Jobs_Queue_API.php
@@ -38,19 +38,19 @@ class Pods_Jobs_Queue_API {
 		$tables = array();
 
 		$tables[] = "
-			CREATE TABLE `{$table}` (
-				`id` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
-				`callback` VARCHAR(255) NOT NULL,
-				`arguments` LONGTEXT NOT NULL,
-				`blog_id` BIGINT(20) NOT NULL,
-				`memo` VARCHAR(255) NOT NULL,
-				`group` VARCHAR(255) NOT NULL,
-				`status` VARCHAR(10) NOT NULL,
-				`date_queued` DATETIME NOT NULL,
-				`date_started` DATETIME NOT NULL,
-				`date_completed` DATETIME NOT NULL,
-				`log` LONGTEXT NOT NULL,
-				PRIMARY KEY (`id`)
+			CREATE TABLE {$table} (
+				id INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+				callback VARCHAR(255) NOT NULL,
+				arguments LONGTEXT NOT NULL,
+				blog_id BIGINT(20) NOT NULL,
+				memo VARCHAR(255) NOT NULL,
+				job_group VARCHAR(255) NOT NULL,
+				status VARCHAR(10) NOT NULL,
+				date_queued DATETIME NOT NULL,
+				date_started DATETIME NOT NULL,
+				date_completed DATETIME NOT NULL,
+				log LONGTEXT NOT NULL,
+				UNIQUE KEY (id)
 			)
 		";
 
@@ -77,7 +77,7 @@ class Pods_Jobs_Queue_API {
 		$table = self::table();
 
 		// Delete table if it exists
-		$wpdb->query( "DROP TABLE IF EXISTS `{$table}`" );
+		$wpdb->query( "DROP TABLE IF EXISTS {$table}" );
 
 	}
 
@@ -102,9 +102,9 @@ class Pods_Jobs_Queue_API {
 		$table = self::table();
 
 		$sql = "
-			SELECT * FROM `{$table}`
-			WHERE `status` = %s
-			ORDER BY `date_queued`, `id`
+			SELECT * FROM {$table}
+			WHERE status = %s
+			ORDER BY date_queued, id
 			LIMIT 1
 		";
 
@@ -142,8 +142,8 @@ class Pods_Jobs_Queue_API {
 		$table = self::table();
 
 		$sql = "
-			SELECT * FROM `{$table}`
-			WHERE `id` = %d
+			SELECT * FROM {$table}
+			WHERE id = %d
 		";
 
 		$item = $wpdb->get_row( $wpdb->prepare( $sql, $job_id ), ARRAY_A );

--- a/Pods_Jobs_Queue_Admin.php
+++ b/Pods_Jobs_Queue_Admin.php
@@ -102,7 +102,7 @@ class Pods_Jobs_Queue_Admin {
 						'label' => 'Callback',
 						'type' => 'text'
 					),
-					'group' =>  array(
+					'job_group' =>  array(
 						'name' => 'group',
 						'label' => 'Group',
 						'type' => 'text'
@@ -154,7 +154,7 @@ class Pods_Jobs_Queue_Admin {
 			'filters' => array(
 				'callback',
 				'memo',
-				'group',
+				'job_group',
 				'status',
 				'date_queued',
 				'date_started',
@@ -191,7 +191,7 @@ class Pods_Jobs_Queue_Admin {
 
 		$ui[ 'fields' ][ 'search' ][ 'callback' ] = $ui[ 'fields' ][ 'manage' ][ 'callback' ];
 		$ui[ 'fields' ][ 'search' ][ 'memo' ] = $ui[ 'fields' ][ 'manage' ][ 'memo' ];
-		$ui[ 'fields' ][ 'search' ][ 'group' ] = $ui[ 'fields' ][ 'manage' ][ 'group' ];
+		$ui[ 'fields' ][ 'search' ][ 'job_group' ] = $ui[ 'fields' ][ 'manage' ][ 'job_group' ];
 		$ui[ 'fields' ][ 'search' ][ 'status' ] = $ui[ 'fields' ][ 'manage' ][ 'status' ];
 		$ui[ 'fields' ][ 'search' ][ 'date_queued' ] = $ui[ 'fields' ][ 'manage' ][ 'date_queued' ];
 		$ui[ 'fields' ][ 'search' ][ 'date_started' ] = $ui[ 'fields' ][ 'manage' ][ 'date_started' ];
@@ -225,11 +225,11 @@ class Pods_Jobs_Queue_Admin {
 		);
 
 		if ( ! defined( 'PODS_JOBS_QUEUE_GROUPS' ) || ! PODS_JOBS_QUEUE_GROUPS ) {
-			unset( $ui[ 'fields' ][ 'manage' ][ 'group' ] );
+			unset( $ui[ 'fields' ][ 'manage' ][ 'job_group' ] );
 			unset( $ui[ 'fields' ][ 'manage' ][ 'search' ] );
 			unset( $ui[ 'fields' ][ 'manage' ][ 'view' ] );
 
-			unset( $ui[ 'filters' ][ array_search( 'group', $ui[ 'filters' ] ) ] );
+			unset( $ui[ 'filters' ][ array_search( 'job_group', $ui[ 'filters' ] ) ] );
 		}
 
 		if ( 1 == pods_v( 'deleted_bulk' ) ) {


### PR DESCRIPTION
After trying to install the plugin, i received a lot of errors in the WP Admin regarding MYSQL syntax errors.

1) Removed backticks --> 
http://codex.wordpress.org/Creating_Tables_with_Plugins
You must not use any apostrophes or backticks around field names.

2) Renamed the column 'Group' -->
http://dev.mysql.com/doc/refman/5.0/en/reserved-words.html
Group is a reserved word

3) Changed Primary Key to Unique Key -->
Similar in function but allows dbDelta to work properly
http://onetarek.com/wordpress/wordpress-dbdelta-database-error-multiple-primary-key-defined/
http://stackoverflow.com/questions/3844899/difference-between-key-primary-key-unique-key-and-index-in-mysql
